### PR TITLE
Avoid runtime error in MismatchName

### DIFF
--- a/lib/rubocop/cop/yard/mismatch_name.rb
+++ b/lib/rubocop/cop/yard/mismatch_name.rb
@@ -29,6 +29,7 @@ module RuboCop
           yard_docstring = preceding_lines.map { |line| line.text.gsub(/\A#\s*/, '') }.join("\n")
           docstring = ::YARD::DocstringParser.new.parse(yard_docstring)
           docstring.tags.each do |tag|
+            next unless tag.name
             next unless tag.tag_name == 'param' || tag.tag_name == 'option'
             next unless node.arguments.none? { |arg_node| tag.name.to_sym == arg_node.name }
 


### PR DESCRIPTION
The following autocorrection is not performed because an error occurs in runtime.

```ruby
class Foo
  # @return [void] この行はYard::Tags::Tag#nameがnilとなります
  def foo
    # do something
  end
end
```

I added early return when Tag does not have name to fix this problem.