### PR TITLE
Fix `comparison of Integer with nil failed` in `YARD/MeaninglessTag`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,8 @@ namespace :smoke do
       { name: "tag_type_syntax" }
     ],
     'YARD/MeaninglessTag' => [
-      { name: "meaningless_tag" }
+      { name: "meaningless_tag" },
+      { name: "meaningless_tag_n_plus_one_query" },
     ],
     'YARD/MismatchName' => [
       { name: "mismatch_name", correct: true }

--- a/lib/rubocop/cop/yard/helper.rb
+++ b/lib/rubocop/cop/yard/helper.rb
@@ -78,7 +78,7 @@ module RuboCop
 
         def build_docstring(preceding_lines)
           comment_texts = preceding_lines.map { |l| l.text.gsub(/\A#/, '') }
-          minimum_space = comment_texts.map { |t| t.index(/[^\s]/) }.min
+          minimum_space = comment_texts.map { |t| t.index(/[^\s]/) }.compact.min
           yard_docstring = comment_texts.map { |t| t[minimum_space..-1] }.join("\n")
           begin
             ::YARD::DocstringParser.new.parse(yard_docstring)

--- a/smoke/generated/meaningless_tag_n_plus_one_query.json
+++ b/smoke/generated/meaningless_tag_n_plus_one_query.json
@@ -1,0 +1,20 @@
+{
+  "metadata": {
+    "rubocop_version": "1.57.2",
+    "ruby_engine": "ruby",
+    "ruby_version": "3.2.2",
+    "ruby_patchlevel": "53",
+    "ruby_platform": "arm64-darwin22"
+  },
+  "files": [
+    {
+      "path": "smoke/meaningless_tag_n_plus_one_query.rb",
+      "offenses": []
+    }
+  ],
+  "summary": {
+    "offense_count": 0,
+    "target_file_count": 1,
+    "inspected_file_count": 1
+  }
+}

--- a/smoke/meaningless_tag_n_plus_one_query.rb
+++ b/smoke/meaningless_tag_n_plus_one_query.rb
@@ -1,0 +1,44 @@
+# Checks that there’s no N+1 query
+#
+# @note If `Database` isn't configured, auto-correct will not be available. (Only offense detection can be used)
+#
+# @note For the number of N+1 queries that can be detected by this cop, there are too few that can be corrected automatically
+#
+# @example
+#   # bad
+#   reservations = db.xquery('SELECT * FROM `reservations` WHERE `schedule_id` = ?', schedule_id).map do |reservation|
+#     reservation[:user] = db.xquery('SELECT * FROM `users` WHERE `id` = ? LIMIT 1', id).first
+#     reservation
+#   end
+#
+#   # good
+#   rows = db.xquery(<<~SQL, schedule_id)
+#     SELECT
+#       r.id AS reservation_id,
+#       r.schedule_id AS reservation_schedule_id,
+#       r.user_id AS reservation_user_id,
+#       r.created_at AS reservation_created_at,
+#       u.id AS user_id,
+#       u.email AS user_email,
+#       u.nickname AS user_nickname,
+#       u.staff AS user_staff,
+#       u.created_at AS user_created_at
+#     FROM `reservations` AS r
+#     INNER JOIN users u ON u.id = r.user_id
+#     WHERE r.schedule_id = ?
+#   SQL
+#
+#   # bad
+#   courses.map do |course|
+#     teacher = db.xquery('SELECT * FROM `users` WHERE `id` = ?', course[:teacher_id]).first
+#   end
+#
+#   # good
+#   # This is similar to ActiveRecord's preload
+#   # c.f. https://guides.rubyonrails.org/active_record_querying.html#preload
+#   courses.map do |course|
+#     @users_by_id ||= db.xquery('SELECT * FROM `users` WHERE `id` IN (?)', courses.map { |course| course[:teacher_id] }).each_with_object({}) { |v, hash| hash[v[:id]] = v }
+#     teacher = @users_by_id[course[:teacher_id]]
+#   end
+class NPlusOneQuery < Base
+end


### PR DESCRIPTION
Since rubocop-yard v0.9.1, I have been getting the following error (v0.9.0 has no problem)

<details>
<summary>backtrace</summary>

```
[sue445@sue445-M1-MBA.local] [12-09 16:29:04] $ bundle exec rubocop -d -- lib/rubocop/cop/isucon/mysql2/n_plus_one_query.rb
For /Users/sue445/workspace/github.com/sue445/rubocop-isucon: configuration from /Users/sue445/workspace/github.com/sue445/rubocop-isucon/.rubocop.yml
configuration from /Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-performance-1.19.1/config/default.yml
configuration from /Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-performance-1.19.1/config/default.yml
Default configuration from /Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/config/default.yml
configuration from /Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-yard-0.9.1/config/default.yml
configuration from /Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-yard-0.9.1/config/default.yml
Use parallel by default.
Skipping parallel inspection: only a single file needs inspection
Inspecting 1 file
Scanning /Users/sue445/workspace/github.com/sue445/rubocop-isucon/lib/rubocop/cop/isucon/mysql2/n_plus_one_query.rb
An error occurred while YARD/MeaninglessTag cop was inspecting /Users/sue445/workspace/github.com/sue445/rubocop-isucon/lib/rubocop/cop/isucon/mysql2/n_plus_one_query.rb:51:8.
comparison of Integer with nil failed
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-yard-0.9.1/lib/rubocop/cop/yard/helper.rb:81:in `min'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-yard-0.9.1/lib/rubocop/cop/yard/helper.rb:81:in `build_docstring'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-yard-0.9.1/lib/rubocop/cop/yard/meaningless_tag.rb:38:in `check'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-yard-0.9.1/lib/rubocop/cop/yard/meaningless_tag.rb:29:in `on_class'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/cop/commissioner.rb:107:in `public_send'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/cop/commissioner.rb:107:in `block (2 levels) in trigger_responding_cops'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/cop/commissioner.rb:171:in `with_cop_error_handling'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/cop/commissioner.rb:106:in `block in trigger_responding_cops'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/cop/commissioner.rb:105:in `each'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/cop/commissioner.rb:105:in `trigger_responding_cops'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/cop/commissioner.rb:69:in `on_class'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-ast-1.30.0/lib/rubocop/ast/traversal.rb:138:in `on_while'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/cop/commissioner.rb:71:in `on_module'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-ast-1.30.0/lib/rubocop/ast/traversal.rb:138:in `on_while'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/cop/commissioner.rb:71:in `on_module'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-ast-1.30.0/lib/rubocop/ast/traversal.rb:138:in `on_while'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/cop/commissioner.rb:71:in `on_module'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-ast-1.30.0/lib/rubocop/ast/traversal.rb:138:in `on_while'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/cop/commissioner.rb:71:in `on_module'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-ast-1.30.0/lib/rubocop/ast/traversal.rb:20:in `walk'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/cop/commissioner.rb:87:in `investigate'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/cop/team.rb:156:in `investigate_partial'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/cop/team.rb:98:in `investigate'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/runner.rb:345:in `block in inspect_file'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/runner.rb:344:in `each'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/runner.rb:344:in `flat_map'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/runner.rb:344:in `inspect_file'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/runner.rb:287:in `block in do_inspection_loop'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/runner.rb:321:in `block in iterate_until_no_changes'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/runner.rb:314:in `loop'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/runner.rb:314:in `iterate_until_no_changes'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/runner.rb:283:in `do_inspection_loop'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/runner.rb:164:in `block in file_offenses'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/runner.rb:189:in `file_offense_cache'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/runner.rb:163:in `file_offenses'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/runner.rb:154:in `process_file'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/runner.rb:135:in `block in each_inspected_file'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/runner.rb:134:in `each'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/runner.rb:134:in `reduce'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/runner.rb:134:in `each_inspected_file'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/runner.rb:120:in `inspect_files'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/runner.rb:73:in `run'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/cli/command/execute_runner.rb:26:in `block in execute_runner'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/cli/command/execute_runner.rb:52:in `with_redirect'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/cli/command/execute_runner.rb:25:in `execute_runner'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/cli/command/execute_runner.rb:17:in `run'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/cli/command.rb:11:in `run'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/cli/environment.rb:18:in `run'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/cli.rb:118:in `run_command'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/cli.rb:125:in `execute_runners'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/cli.rb:51:in `block in run'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/cli.rb:77:in `profile_if_needed'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/lib/rubocop/cli.rb:43:in `run'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/exe/rubocop:19:in `block in <top (required)>'
/Users/sue445/.rbenv/versions/3.2.2/lib/ruby/3.2.0/benchmark.rb:311:in `realtime'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/gems/rubocop-1.58.0/exe/rubocop:19:in `<top (required)>'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/bin/rubocop:25:in `load'
/Users/sue445/workspace/github.com/sue445/rubocop-isucon/vendor/bundle/ruby/3.2.0/bin/rubocop:25:in `<top (required)>'
/Users/sue445/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/cli/exec.rb:58:in `load'
/Users/sue445/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/cli/exec.rb:58:in `kernel_load'
/Users/sue445/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/cli/exec.rb:23:in `run'
/Users/sue445/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/cli.rb:492:in `exec'
/Users/sue445/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/Users/sue445/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/Users/sue445/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
/Users/sue445/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/cli.rb:34:in `dispatch'
/Users/sue445/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
/Users/sue445/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/cli.rb:28:in `start'
/Users/sue445/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.10/libexec/bundle:45:in `block in <top (required)>'
/Users/sue445/.rbenv/versions/3.2.2/lib/ruby/3.2.0/bundler/friendly_errors.rb:117:in `with_friendly_errors'
/Users/sue445/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.10/libexec/bundle:33:in `<top (required)>'
/Users/sue445/.rbenv/versions/3.2.2/bin/bundle:25:in `load'
/Users/sue445/.rbenv/versions/3.2.2/bin/bundle:25:in `<main>'
.

1 file inspected, no offenses detected

1 error occurred:
An error occurred while YARD/MeaninglessTag cop was inspecting /Users/sue445/workspace/github.com/sue445/rubocop-isucon/lib/rubocop/cop/isucon/mysql2/n_plus_one_query.rb:51:8.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
https://github.com/rubocop/rubocop/issues

Mention the following information in the issue report:
1.58.0 (using Parser 3.2.2.4, rubocop-ast 1.30.0, running on ruby 3.2.2) [arm64-darwin22]
Finished in 0.1444899999999052 seconds
```

</details>

So I fixed this error.

