### PR TITLE
Suppress YARD warning logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Suppress YARD warning logs
+
 ## [0.9.0] - 2023-11-28
 
 - Add `YARD/TagTypePosition`

--- a/lib/rubocop/cop/yard/helper.rb
+++ b/lib/rubocop/cop/yard/helper.rb
@@ -81,7 +81,9 @@ module RuboCop
           minimum_space = comment_texts.map { |t| t.index(/[^\s]/) }.compact.min
           yard_docstring = comment_texts.map { |t| t[minimum_space..-1] }.join("\n")
           begin
-            ::YARD::DocstringParser.new.parse(yard_docstring)
+            ::YARD::Logger.instance.enter_level(::YARD::Logger::ERROR) do
+              ::YARD::DocstringParser.new.parse(yard_docstring)
+            end
           rescue
             nil
           end


### PR DESCRIPTION
Fixed https://github.com/ksss/rubocop-yard/issues/25

When rubocop is executed, the warning of YARD itself should not be output,
but should be reported as an offenct of rubocop.