### PR TITLE
Adds a missing case for mismatch name

### DIFF
--- a/lib/rubocop/cop/yard/mismatch_name.rb
+++ b/lib/rubocop/cop/yard/mismatch_name.rb
@@ -67,7 +67,7 @@ module RuboCop
 
           # Documentation only or just `@return` is a common form of documentation.
           # The subsequent features will be limited to cases where both `@param` and `@option` are present.
-          unless docstring.tags.find { |tag| (tag.tag_name == 'param' && !tag.instance_of?(::YARD::Tags::RefTagList)) || tag.tag_name == 'option' }
+          unless docstring.tags.find { |tag| (tag.tag_name == 'param' && !(tag.instance_of?(::YARD::Tags::RefTagList) && tag.name.nil?)) || tag.tag_name == 'option' }
             return false
           end
           node.arguments.each do |argument|

--- a/smoke/generated/mismatch_name.json
+++ b/smoke/generated/mismatch_name.json
@@ -124,17 +124,33 @@
         },
         {
           "severity": "convention",
+          "message": "This method has argument `arg2`, But not documented",
+          "cop_name": "YARD/MismatchName",
+          "corrected": false,
+          "correctable": true,
+          "location": {
+            "start_line": 33,
+            "start_column": 3,
+            "last_line": 33,
+            "last_column": 28,
+            "length": 26,
+            "line": 33,
+            "column": 3
+          }
+        },
+        {
+          "severity": "convention",
           "message": "`context,` is not found in method arguments of [context]",
           "cop_name": "YARD/MismatchName",
           "corrected": false,
           "correctable": false,
           "location": {
-            "start_line": 52,
+            "start_line": 56,
             "start_column": 18,
-            "last_line": 52,
+            "last_line": 56,
             "last_column": 25,
             "length": 8,
-            "line": 52,
+            "line": 56,
             "column": 18
           }
         }
@@ -142,7 +158,7 @@
     }
   ],
   "summary": {
-    "offense_count": 8,
+    "offense_count": 9,
     "target_file_count": 1,
     "inspected_file_count": 1
   }

--- a/smoke/generated/mismatch_name_correct.rb
+++ b/smoke/generated/mismatch_name_correct.rb
@@ -34,6 +34,11 @@ class Foo
   def ref_only(arg)
   end
 
+  # @param arg1 (see #other)
+  # @param [Object] arg2
+  def partial_ref(arg1, arg2)
+  end
+
   # @param [String] arg
   def rest_block(arg, *, **, &block)
   end

--- a/smoke/mismatch_name.rb
+++ b/smoke/mismatch_name.rb
@@ -30,6 +30,10 @@ class Foo
   def ref_only(arg)
   end
 
+  # @param arg1 (see #other)
+  def partial_ref(arg1, arg2)
+  end
+
   # @param [String] arg
   def rest_block(arg, *, **, &block)
   end


### PR DESCRIPTION
Currently, the `YARD/MismatchName` only complains if there's at least one parameter documented.

However, if we document a param by using a reference to another method, but forget to document others, it does not alert.

This fixes that corner case while keeping the other cases working as expected. I added a smoke test for this particular case and regenerated the diffs.