### PR TITLE
Fix NoMethodError when method signature includes **nil

### DIFF
--- a/lib/rubocop/cop/yard/mismatch_name.rb
+++ b/lib/rubocop/cop/yard/mismatch_name.rb
@@ -72,7 +72,8 @@ module RuboCop
           end
           node.arguments.each do |argument|
             next if argument.type == :blockarg
-            next if argument.name.nil?
+            next if argument.type == :kwnilarg
+            next if !argument.respond_to?(:name) || argument.name.nil?
 
             found = docstring.tags.find do |tag|
               next unless tag.tag_name == 'param' || tag.tag_name == 'option'

--- a/spec/rubocop/cop/yard/mismatch_name_spec.rb
+++ b/spec/rubocop/cop/yard/mismatch_name_spec.rb
@@ -102,6 +102,10 @@ RSpec.describe RuboCop::Cop::YARD::MismatchName, :config do
         #   arg multiline doc
         def multiline_param(arg)
         end
+
+        # @param text [Array<String>]
+        def kwnilarg(text, **nil)
+        end
       end
     RUBY
   end


### PR DESCRIPTION
Fixes #37

## Problem

The MismatchName cop raised `NoMethodError` when checking methods with `**nil` in their signature:

```ruby
# @param text [Array<String>]
def test(text, **nil)
end
```

Error: `undefined method 'name' for an instance of RuboCop::AST::Node`

## Solution

- Skip `:kwnilarg` type arguments explicitly
- Add `respond_to?(:name)` check before accessing `name`
- Add test case for `**nil` syntax

## Testing

```bash
bundle exec rspec  # 19 examples, 0 failures
```