### PR TITLE
Allow @param on Struct/Data constant assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+* `YARD/MeaninglessTag`: Allow `@param` on `Struct.new`/`Data.define` constant assignments (https://github.com/ksss/rubocop-yard/issues/36)
+
 ## [1.1.0] - 2026-01-29
 
 * Fix NoMethodError when method signature includes **nil by @ksss in https://github.com/ksss/rubocop-yard/pull/39

--- a/lib/rubocop/cop/yard/meaningless_tag.rb
+++ b/lib/rubocop/cop/yard/meaningless_tag.rb
@@ -19,11 +19,25 @@ module RuboCop
       #
       #   # good
       #   CONST = 1
+      #
+      #   # good (Struct/Data constant assignments accept @param)
+      #   # @param name [String]
+      #   # @param age [Integer]
+      #   Person = Struct.new(:name, :age, keyword_init: true)
       class MeaninglessTag < Base
         include YARD::Helper
         include RangeHelp
         include DocumentationComment
         extend AutoCorrector
+
+        # @!method struct_or_data_definition?(node)
+        #   @param node [RuboCop::AST::Node]
+        def_node_matcher :struct_or_data_definition?, <<~PATTERN
+          (casgn _ _ {
+            (block (send (const _ {:Struct :Data}) {:new :define} ...) ...)
+            (send (const _ {:Struct :Data}) {:new :define} ...)
+          })
+        PATTERN
 
         def on_class(node)
           check(node)
@@ -40,6 +54,7 @@ module RuboCop
 
           docstring.tags.each do |tag|
             next unless tag.tag_name == 'param' || tag.tag_name == 'option'
+            next if tag.tag_name == 'param' && struct_or_data_definition?(node)
 
             comment = preceding_lines.find { |line| line.text.include?("@#{tag.tag_name}") }
             next unless comment

--- a/spec/rubocop/cop/yard/meaningless_tag_spec.rb
+++ b/spec/rubocop/cop/yard/meaningless_tag_spec.rb
@@ -36,4 +36,31 @@ RSpec.describe RuboCop::Cop::YARD::MeaninglessTag, :config do
       end
     RUBY
   end
+
+  it 'does not register an offense for @param on Struct/Data constant assignments' do
+    expect_no_offenses(<<~RUBY)
+      # @param required_gems [Array<String>]
+      # @param helper_modules [Array<String>]
+      GemHelpers = Struct.new(:required_gems, :helper_modules, keyword_init: true)
+
+      # @param name [String]
+      Point = Data.define(:name)
+
+      # @param x [Integer]
+      # @param y [Integer]
+      WithBlock = Struct.new(:x, :y) do
+        def sum
+          x + y
+        end
+      end
+    RUBY
+  end
+
+  it 'still registers an offense for @option on Struct/Data constant assignments' do
+    expect_offense(<<~RUBY)
+      # @option opts [String] :key
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `@option` is meaningless tag on casgn
+      GemHelpers = Struct.new(:required_gems, keyword_init: true)
+    RUBY
+  end
 end


### PR DESCRIPTION
## Summary
- `YARD/MeaninglessTag` no longer flags `@param` on `Struct.new` / `Data.define` constant assignments (with or without a block).
- `@option` on those assignments is still flagged, since Solargraph's new support is `@param`-specific.

Closes #36. See referenced Solargraph PRs in the issue for the upstream behavior change.

## Test plan
- [x] `bundle exec rspec` (21 examples, 0 failures)
- [x] `bundle exec rubocop` on changed files (clean)
- [x] New specs cover `Struct.new`, `Data.define`, block form, and the `@option`-still-flagged case

🤖 Generated with [Claude Code](https://claude.com/claude-code)