### PR TITLE
Guard against YARD parser type/explainer size mismatch

### DIFF
--- a/lib/rubocop/cop/yard/helper.rb
+++ b/lib/rubocop/cop/yard/helper.rb
@@ -25,6 +25,8 @@ module RuboCop
 
             begin
               types_explainers = parse_type(types.join(', '))
+              next if types.size != types_explainers.size
+
               types.zip(types_explainers).each do |type, types_explainer|
                 block.call(type, types_explainer)
               end

--- a/spec/rubocop/cop/yard/collection_style_spec.rb
+++ b/spec/rubocop/cop/yard/collection_style_spec.rb
@@ -108,4 +108,19 @@ RSpec.describe RuboCop::Cop::YARD::CollectionStyle, :config do
       RUBY
     end
   end
+
+  context 'when YARD parses types into a different number of explainers' do
+    let(:cop_config) { { 'EnforcedStyle' => 'long' } }
+
+    # @see https://github.com/ksss/rubocop-yard/issues/43
+    it 'does not register an offense or destructively autocorrect' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          # @return [Array<Hash{Symbol => String}>, nil]
+          def foo
+          end
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Fixes #43.

For a type like `[Array<Hash{Symbol => String}>, nil]`, YARD's `TypesExplainer` parser returns only one explainer for the two types (upstream bug lsegal/yard#1688). `Helper#each_types_explainer` then zipped the 2-element `types` array against the 1-element explainers array, which made `YARD/CollectionStyle`:

1. emit a **destructive autocorrect** from the wrongly-parsed explainer (`[Array<Hash{Symbol => String, nil}>]` — this changes the meaning of `nil`), and
2. **crash** on the trailing `nil` with `NilClass is not supported`.

The destructive rewrite is the more serious of the two, since it lands in the file before the crash aborts the iteration.

## Fix

In `each_types_explainer`, skip the tag with `next` when `types.size != types_explainers.size`. This mirrors the existing `rescue SyntaxError` policy (let suspicious tags pass through without an offense). Since this is a shared helper, it protects both `CollectionStyle` and `CollectionType`.

I deliberately did not add a `nil` guard to `styled_string`, as it could mask other genuine problems.

## Test

- Added the issue's repro case to `collection_style_spec.rb` via `expect_no_offenses`
- All 22 existing specs pass
- Verified with `rubocop --only YARD/CollectionStyle -a` that the repro file is left intact and no offense is reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)